### PR TITLE
Add http2 support to zibai

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,14 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-13]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: pdm-project/setup-pdm@v3
+      - uses: pdm-project/setup-pdm@v4
         name: Setup Python and PDM
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-          version: 2.10.4
+          version: 2.25.9
 
       - name: Install dependencies
         run: |
@@ -57,14 +57,14 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: pdm-project/setup-pdm@v3
+      - uses: pdm-project/setup-pdm@v4
         name: Setup Python and PDM
         with:
           python-version: "3.10"
           architecture: x64
-          version: 2.10.4
+          version: 2.25.9
 
       - name: Build package distributions
         run: |

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ options:
   --watchfiles WATCHFILES
                         watch files for changes and restart workers (default: None)
   --backlog BACKLOG     listen backlog (default: None)
-  --socket-timeout SOCKET_TIMEOUT
-                        socket timeout (other means keepalive timeout) (default: None)
+  --keepalive-timeout KEEPALIVE_TIMEOUT
+                        keepalive timeout (seconds) for idle connections (default: None)
   --dualstack-ipv6      enable dualstack ipv6 (default: False)
   --unix-socket-perms UNIX_SOCKET_PERMS
                         unix socket permissions (default: 600)

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "benchmark", "gevent", "reload", "test"]
 strategy = ["cross_platform"]
 lock_version = "4.5.0"
-content_hash = "sha256:b01b8f07472d815ed30233c2884b231bf3d15f3412d15960e6f125667e430a87"
+content_hash = "sha256:4080c15fa0064b5b6d5c68c275317154daed8e8971f463e8b605be384b2af3e7"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -366,6 +366,19 @@ dependencies = [
 files = [
     {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
     {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+requires_python = ">=3.7"
+summary = "pytest plugin to abort hanging tests"
+dependencies = [
+    "pytest>=7.0.0",
+]
+files = [
+    {file = "pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"},
+    {file = "pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,10 +2,13 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "gevent", "reload", "benchmark", "test"]
+groups = ["default", "benchmark", "gevent", "reload", "test"]
 strategy = ["cross_platform"]
-lock_version = "4.4.1"
-content_hash = "sha256:4c090a355ff8642a98f103026b94ba19e0cc0755623bbc8740782e6d2a154bfc"
+lock_version = "4.5.0"
+content_hash = "sha256:b01b8f07472d815ed30233c2884b231bf3d15f3412d15960e6f125667e430a87"
+
+[[metadata.targets]]
+requires_python = ">=3.10"
 
 [[package]]
 name = "cffi"
@@ -257,6 +260,40 @@ summary = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 files = [
     {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
     {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+requires_python = ">=3.9"
+summary = "Pure-Python HTTP/2 protocol implementation"
+dependencies = [
+    "hpack<5,>=4.1",
+    "hyperframe<7,>=6.1",
+]
+files = [
+    {file = "h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"},
+    {file = "h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1"},
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+requires_python = ">=3.9"
+summary = "Pure-Python HPACK header encoding"
+files = [
+    {file = "hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"},
+    {file = "hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"},
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+requires_python = ">=3.9"
+summary = "Pure-Python HTTP/2 framing"
+files = [
+    {file = "hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"},
+    {file = "hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,6 @@ benchmark = [
     "waitress>=2.1.2",
     "gunicorn>=21.2.0",
 ]
-test = [
-    "pytest>=7.4.3",
-    "pytest-cov>=4.1.0",
-]
 
 [tool.pdm.scripts]
 format = "ruff format ."
@@ -73,5 +69,12 @@ show_missing = true
 skip_covered = true
 
 [tool.pytest.ini_options]
-timeout = 300
+timeout = 10
 timeout_method = "thread"
+
+[dependency-groups]
+test = [
+    "pytest>=7.4.3",
+    "pytest-cov>=4.1.0",
+    "pytest-timeout>=2.4.0",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 dependencies = [
     "h11>=0.14.0",
+    "h2>=4.1.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 dependencies = [
     "h11>=0.14.0",
-    "h2>=4.1.0",
+    "h2>=4.3.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ show_missing = true
 skip_covered = true
 
 [tool.pytest.ini_options]
-timeout = 10
+timeout = 300
 timeout_method = "thread"
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,7 @@ exclude_lines = [
 ]
 show_missing = true
 skip_covered = true
+
+[tool.pytest.ini_options]
+timeout = 300
+timeout_method = "thread"

--- a/src/zibai/cli.py
+++ b/src/zibai/cli.py
@@ -28,7 +28,7 @@ class Options:
     watchfiles: str | None = None
 
     backlog: int | None = None
-    socket_timeout: float = 5
+    keepalive_timeout: float = 5
     dualstack_ipv6: bool = False
     unix_socket_perms: int = 0o600
     h11_max_incomplete_event_size: int | None = None
@@ -252,11 +252,20 @@ def parse_args(args: Sequence[str]) -> Options:
         help="listen backlog",
         required=False,
     )
+    # Prefer keepalive-timeout; keep legacy --socket-timeout for backward compatibility
+    parser.add_argument(
+        "--keepalive-timeout",
+        type=float,
+        help="keepalive timeout (seconds) for idle connections",
+        required=False,
+        dest="keepalive_timeout",
+    )
     parser.add_argument(
         "--socket-timeout",
         type=float,
-        help="socket timeout (other means keepalive timeout)",
+        help="[deprecated] alias of --keepalive-timeout",
         required=False,
+        dest="keepalive_timeout",
     )
     parser.add_argument(
         "--dualstack-ipv6",
@@ -427,5 +436,5 @@ def main(options: Options, *, is_main: bool = True) -> None:
         before_serve_hook=options.get_before_serve_hook(),
         before_graceful_exit_hook=options.get_before_graceful_exit_hook(),
         before_died_hook=options.get_before_died_hook(),
-        socket_timeout=options.socket_timeout,
+        keepalive_timeout=options.keepalive_timeout,
     )

--- a/src/zibai/core.py
+++ b/src/zibai/core.py
@@ -189,16 +189,10 @@ def handle_connection(
     with connection:
         try:
             connections.add(connection)
+
             # Protocol detection: HTTP/2 (h2c) preface vs HTTP/1.1
-            # Do a single peek respecting socket timeout; decide based on prefix
-            is_h2c = False
-            try:
-                peeked = connection.recv(len(H2_CLIENT_PREFACE), socket.MSG_PEEK)
-            except (BlockingIOError, TimeoutError, ConnectionError, OSError, socket.timeout):
-                peeked = b""
-            # If we see the beginning of the HTTP/2 preface ("PRI "), or a full match, treat as h2c
-            if peeked and (peeked.startswith(H2_CLIENT_PREFACE) or H2_CLIENT_PREFACE.startswith(peeked) or peeked.startswith(b"PRI ")):
-                is_h2c = True
+            peeked = connection.recv(len(H2_CLIENT_PREFACE), socket.MSG_PEEK)
+            is_h2c = peeked == H2_CLIENT_PREFACE
 
             if is_h2c:
                 debug_logger.debug("[core] using h2c for %r", address)

--- a/src/zibai/core.py
+++ b/src/zibai/core.py
@@ -211,7 +211,7 @@ def handle_connection(
                 break
 
             if is_h2c:
-                print('[core] using h2c for', address)
+                debug_logger.debug("[core] using h2c for %r", address)
                 http2_protocol(
                     app,
                     connection,
@@ -220,7 +220,7 @@ def handle_connection(
                     script_name=script_name,
                 )
             else:
-                print('[core] using http/1.1 for', address)
+                debug_logger.debug("[core] using http/1.1 for %r", address)
                 http11_protocol(
                     app,
                     connection,

--- a/src/zibai/core.py
+++ b/src/zibai/core.py
@@ -105,7 +105,7 @@ def serve(
     before_serve_hook: Callable[[], None] = lambda: None,
     before_graceful_exit_hook: Callable[[], None] = lambda: None,
     before_died_hook: Callable[[], None] = lambda: None,
-    socket_timeout: float = 5,
+    keepalive_timeout: float = 5,
 ) -> None:
     """
     Serve a WSGI application.
@@ -158,7 +158,7 @@ def serve(
                         connection,
                         address,
                         graceful_exit,
-                        socket_timeout,
+                        keepalive_timeout,
                         connections,
                         url_scheme=url_scheme,
                         script_name=script_name,
@@ -178,13 +178,14 @@ def handle_connection(
     connection: socket.socket,
     address: tuple[str, int],
     graceful_exit: threading.Event,
-    socket_timeout: float,
+    keepalive_timeout: float,
     connections: set[socket.socket],
     *,
     url_scheme: str = "http",
     script_name: str = "",
 ) -> None:
-    connection.settimeout(socket_timeout)
+    # Keepalive timeout: maximum idle wait per blocking recv on this connection
+    connection.settimeout(keepalive_timeout)
     debug_logger.debug("Handling connection from %s:%d", *address[:2])
     with connection:
         try:

--- a/src/zibai/core.py
+++ b/src/zibai/core.py
@@ -190,25 +190,15 @@ def handle_connection(
         try:
             connections.add(connection)
             # Protocol detection: HTTP/2 (h2c) preface vs HTTP/1.1
-            # Try to detect h2c preface with a short wait window
+            # Do a single peek respecting socket timeout; decide based on prefix
             is_h2c = False
-            import time as _time
-
-            deadline = _time.monotonic() + 0.2
-            while _time.monotonic() < deadline:
-                try:
-                    peeked = connection.recv(
-                        len(H2_CLIENT_PREFACE), socket.MSG_PEEK
-                    )
-                except (BlockingIOError, TimeoutError, ConnectionError, OSError):
-                    peeked = b""
-                if not peeked:
-                    _time.sleep(0.01)
-                    continue
-                if H2_CLIENT_PREFACE.startswith(peeked):
-                    is_h2c = True
-                # We saw some bytes; stop probing
-                break
+            try:
+                peeked = connection.recv(len(H2_CLIENT_PREFACE), socket.MSG_PEEK)
+            except (BlockingIOError, TimeoutError, ConnectionError, OSError, socket.timeout):
+                peeked = b""
+            # If we see the beginning of the HTTP/2 preface ("PRI "), or a full match, treat as h2c
+            if peeked and (peeked.startswith(H2_CLIENT_PREFACE) or H2_CLIENT_PREFACE.startswith(peeked) or peeked.startswith(b"PRI ")):
+                is_h2c = True
 
             if is_h2c:
                 debug_logger.debug("[core] using h2c for %r", address)

--- a/src/zibai/core.py
+++ b/src/zibai/core.py
@@ -190,12 +190,28 @@ def handle_connection(
         try:
             connections.add(connection)
             # Protocol detection: HTTP/2 (h2c) preface vs HTTP/1.1
-            try:
-                preface_peek = connection.recv(len(H2_CLIENT_PREFACE), socket.MSG_PEEK)
-            except (BlockingIOError, TimeoutError, ConnectionError, OSError):
-                preface_peek = b""
+            # Try to detect h2c preface with a short wait window
+            is_h2c = False
+            import time as _time
 
-            if preface_peek == H2_CLIENT_PREFACE:
+            deadline = _time.monotonic() + 0.2
+            while _time.monotonic() < deadline:
+                try:
+                    peeked = connection.recv(
+                        len(H2_CLIENT_PREFACE), socket.MSG_PEEK
+                    )
+                except (BlockingIOError, TimeoutError, ConnectionError, OSError):
+                    peeked = b""
+                if not peeked:
+                    _time.sleep(0.01)
+                    continue
+                if H2_CLIENT_PREFACE.startswith(peeked):
+                    is_h2c = True
+                # We saw some bytes; stop probing
+                break
+
+            if is_h2c:
+                print('[core] using h2c for', address)
                 http2_protocol(
                     app,
                     connection,
@@ -204,6 +220,7 @@ def handle_connection(
                     script_name=script_name,
                 )
             else:
+                print('[core] using http/1.1 for', address)
                 http11_protocol(
                     app,
                     connection,

--- a/src/zibai/core.py
+++ b/src/zibai/core.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Generator, Protocol
 from typing import cast as typing_cast
 
 from .h11 import http11_protocol
+from .h2 import H2_CLIENT_PREFACE, http2_protocol
 from .logger import debug_logger, logger
 from .utils import unicode_to_wsgi
 from .wsgi_typing import WSGIApp
@@ -188,14 +189,28 @@ def handle_connection(
     with connection:
         try:
             connections.add(connection)
+            # Protocol detection: HTTP/2 (h2c) preface vs HTTP/1.1
+            try:
+                preface_peek = connection.recv(len(H2_CLIENT_PREFACE), socket.MSG_PEEK)
+            except (BlockingIOError, TimeoutError, ConnectionError, OSError):
+                preface_peek = b""
 
-            http11_protocol(
-                app,
-                connection,
-                graceful_exit,
-                url_scheme=url_scheme,
-                script_name=script_name,
-            )
+            if preface_peek == H2_CLIENT_PREFACE:
+                http2_protocol(
+                    app,
+                    connection,
+                    graceful_exit,
+                    url_scheme=url_scheme,
+                    script_name=script_name,
+                )
+            else:
+                http11_protocol(
+                    app,
+                    connection,
+                    graceful_exit,
+                    url_scheme=url_scheme,
+                    script_name=script_name,
+                )
         except ConnectionError:
             pass  # client closed connection, nothing to do
         finally:

--- a/src/zibai/h11.py
+++ b/src/zibai/h11.py
@@ -58,7 +58,12 @@ class H11Protocol:
                     try:
                         self.c.receive_data(self.s.recv(MAX_INCOMPLETE_EVENT_SIZE))
                     except socket.timeout:
-                        pass
+                        # Keepalive timeout: if we're idle waiting for a new request,
+                        # close the connection to avoid spinning forever.
+                        if self.c.their_state is h11.IDLE:
+                            raise ConnectionClosed
+                        # If mid-request (e.g., waiting for body), continue waiting.
+                        continue
                 case h11.ConnectionClosed():
                     raise ConnectionClosed
                 case _:

--- a/src/zibai/h2.py
+++ b/src/zibai/h2.py
@@ -46,11 +46,14 @@ class H2Protocol:
             self.s.sendall(data)
 
     def _discard_client_preface(self) -> None:
-        # The client preface must be consumed by the server.
-        preface = self.s.recv(len(H2_CLIENT_PREFACE))
-        if preface != H2_CLIENT_PREFACE:
-            # If it doesn't match, raise to fallback logic.
-            raise ConnectionClosed
+        # Consume exactly the length of the HTTP/2 client preface.
+        need = len(H2_CLIENT_PREFACE)
+        received = 0
+        while received < need:
+            chunk = self.s.recv(need - received)
+            if not chunk:
+                raise ConnectionClosed
+            received += len(chunk)
 
     def _build_environ(self, headers: list[tuple[bytes, bytes]]) -> Environ:
         method = "GET"
@@ -201,7 +204,10 @@ class H2Protocol:
 
     def _recv_and_handle_events(self, *, block_until_window_for: int | None = None) -> None:
         # Minimal event handling to advance flow control; does not process new requests here.
-        data = self.s.recv(65535)
+        try:
+            data = self.s.recv(65535)
+        except socket.timeout:
+            return
         if not data:
             raise ConnectionClosed
         for event in self.c.receive_data(data):
@@ -213,44 +219,61 @@ class H2Protocol:
         self._send_outbound()
 
     def call_wsgi_on_stream(
-        self, wsgi_app: WSGIApp, stream_id: int, headers: list[tuple[bytes, bytes]]
+        self,
+        wsgi_app: WSGIApp,
+        stream_id: int,
+        headers: list[tuple[bytes, bytes]],
+        *,
+        initial_events: list[Any] | None = None,
     ) -> None:
-        # Build environ and set wsgi.input to read from this stream lazily.
-        # We will read Data frames synchronously from the connection as the app requests body.
-        pending_eom = {"value": False}
+        # Read the entire request body for this stream before invoking WSGI.
+        body_chunks: list[bytes] = []
+
+        def consume_events(evts: list[Any]) -> bool:
+            ended = False
+            for event in evts:
+                debug_logger.debug("[h2] body pre-consume event: %r", event)
+                if isinstance(event, h2.events.DataReceived) and event.stream_id == stream_id:
+                    body_chunks.append(event.data)
+                    self.c.acknowledge_received_data(
+                        event.flow_controlled_length, event.stream_id
+                    )
+                if isinstance(event, h2.events.StreamEnded) and event.stream_id == stream_id:
+                    ended = True
+            self._send_outbound()
+            return ended
+
+        if initial_events:
+            ended = consume_events(initial_events)
+            initial_events = []
+        else:
+            ended = False
+        while not ended:
+            try:
+                data = self.s.recv(65535)
+            except socket.timeout:
+                continue
+            if not data:
+                break
+            events = self.c.receive_data(data)
+            ended = consume_events(events)
+
+        # Build environ with a static input source
+        environ = self._build_environ(headers)
+
+        buffer = bytearray(b"".join(body_chunks))
 
         def receive_body() -> bytes:
-            if pending_eom["value"]:
+            if not buffer:
                 return b""
-            # Read events until we get data or end of stream for this stream
-            while True:
-                data = self.s.recv(65535)
-                if not data:
-                    pending_eom["value"] = True
-                    return b""
-                for event in self.c.receive_data(data):
-                    debug_logger.debug(
-                        "[h2] recv body event from %s:%d: %r", *self.peername, event
-                    )
-                    if isinstance(event, h2.events.DataReceived) and event.stream_id == stream_id:
-                        self.c.acknowledge_received_data(
-                            event.flow_controlled_length, event.stream_id
-                        )
-                        self._send_outbound()
-                        return event.data
-                    if isinstance(event, h2.events.StreamEnded) and event.stream_id == stream_id:
-                        pending_eom["value"] = True
-                        self._send_outbound()
-                        return b""
-                self._send_outbound()
+            data = bytes(buffer)
+            buffer.clear()
+            return data
 
-        environ = self._build_environ(headers)
         environ["wsgi.input"] = Input(receive_body)
 
         start_response = self._start_response_factory(stream_id)
         iterable = None
-        status_code = 500
-
         try:
             iterable = wsgi_app(environ, start_response)
             iterator = iter(iterable)
@@ -279,8 +302,12 @@ class H2Protocol:
         except BaseException:
             error_logger.exception("Error while calling WSGI application", exc_info=sys.exc_info())
             # Send 500 if headers not sent
-            # Build minimal 500 response
-            headers = [(":status", "500"), ("content-type", "text/plain; charset=utf-8"), ("content-length", "21"), ("server", SERVER_NAME.decode("latin1"))]
+            headers = [
+                (":status", "500"),
+                ("content-type", "text/plain; charset=utf-8"),
+                ("content-length", "21"),
+                ("server", SERVER_NAME.decode("latin1")),
+            ]
             try:
                 self.c.send_headers(stream_id, headers, end_stream=False)
                 self._send_data_with_flow_control(stream_id, b"Internal Server Error", end_stream=True)
@@ -330,25 +357,38 @@ def http2_protocol(
     h.c.update_settings({SettingCodes.MAX_CONCURRENT_STREAMS: 1})
     h._send_outbound()
 
+    sock.settimeout(1)
     while not graceful_exit.is_set():
         try:
             data = sock.recv(65535)
             if not data:
                 raise ConnectionClosed
             events = h.c.receive_data(data)
-            for event in events:
+            i = 0
+            while i < len(events):
+                event = events[i]
                 debug_logger.debug("[h2] recv event from %s:%d: %r", *h.peername, event)
                 if isinstance(event, h2.events.RequestReceived):
-                    # Serve this request synchronously on this connection
-                    h.call_wsgi_on_stream(app, event.stream_id, event.headers)  # type: ignore[arg-type]
+                    # Collect any remaining events from this batch for this stream
+                    remaining = events[i + 1 :]
+                    h.call_wsgi_on_stream(app, event.stream_id, event.headers, initial_events=remaining)  # type: ignore[arg-type]
+                    break
                 elif isinstance(event, h2.events.ConnectionTerminated):
                     raise ConnectionClosed
                 elif isinstance(event, h2.events.DataReceived):
                     # If body arrives before we try to read it, ack to free window
                     h.c.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
                 # Other events can be safely ignored for minimal server
+                i += 1
             h._send_outbound()
+        except socket.timeout:
+            continue
         except (ConnectionClosed, ConnectionError, OSError):
             debug_logger.debug("[h2] Connection closed by %s:%d", *h.peername)
+            break
+        except Exception:  # pragma: no cover
+            import traceback
+
+            traceback.print_exc()
             break
 

--- a/src/zibai/h2.py
+++ b/src/zibai/h2.py
@@ -40,11 +40,13 @@ class H2Protocol:
         self.script_name = script_name
 
         self.c = h2.connection.H2Connection(config=H2Configuration(client_side=False))
+        self.send_lock = threading.Lock()
 
     def _send_outbound(self) -> None:
-        data = self.c.data_to_send()
-        if data:
-            self.s.sendall(data)
+        with self.send_lock:
+            data = self.c.data_to_send()
+            if data:
+                self.s.sendall(data)
 
     # No explicit preface discard: pass the preface to h2 via receive_data
 
@@ -166,9 +168,12 @@ class H2Protocol:
                 headers.append((k, v))
             # debug
             print('[h2] sending headers', headers)
-            self.c.send_headers(stream_id, headers, end_stream=False)
+            with self.send_lock:
+                self.c.send_headers(stream_id, headers, end_stream=False)
+                data_to_send = self.c.data_to_send()
+                if data_to_send:
+                    self.s.sendall(data_to_send)
             header_sent["value"] = True
-            self._send_outbound()
 
         # Attach helper to the instance for later use within call_wsgi
         start_response._send_headers_if_needed = _send_headers_if_needed  # type: ignore[attr-defined]
@@ -193,8 +198,11 @@ class H2Protocol:
             to_send = data[idx : idx + window]
             idx += len(to_send)
             # Only mark end_stream if this is the last piece
-            self.c.send_data(stream_id, to_send, end_stream=end_stream and idx >= len(data))
-            self._send_outbound()
+            with self.send_lock:
+                self.c.send_data(stream_id, to_send, end_stream=end_stream and idx >= len(data))
+                outbound = self.c.data_to_send()
+                if outbound:
+                    self.s.sendall(outbound)
             if len(to_send) == 0:
                 # End stream with empty data
                 break

--- a/src/zibai/h2.py
+++ b/src/zibai/h2.py
@@ -377,24 +377,35 @@ def http2_protocol(
             if not data:
                 raise ConnectionClosed
             events = h.c.receive_data(data)
-            print('[h2] got events:', [e.__class__.__name__ for e in events])
-            i = 0
-            while i < len(events):
-                event = events[i]
-                debug_logger.debug("[h2] recv event from %s:%d: %r", *h.peername, event)
-                if isinstance(event, h2.events.RequestReceived):
-                    print('[h2] RequestReceived, stream', event.stream_id)
-                    # Collect any remaining events from this batch for this stream
-                    remaining = events[i + 1 :]
-                    h.call_wsgi_on_stream(app, event.stream_id, event.headers, initial_events=remaining)  # type: ignore[arg-type]
-                    break
-                elif isinstance(event, h2.events.ConnectionTerminated):
+            # Group events per stream for any newly received requests.
+            stream_order: list[int] = []
+            stream_headers: dict[int, list[tuple[bytes, bytes]]] = {}
+            stream_evmap: dict[int, list[Any]] = {}
+            for ev in events:
+                debug_logger.debug("[h2] recv event from %s:%d: %r", *h.peername, ev)
+                if isinstance(ev, h2.events.RequestReceived):
+                    stream_id = ev.stream_id
+                    stream_order.append(stream_id)
+                    stream_headers[stream_id] = ev.headers  # type: ignore[assignment]
+                    stream_evmap.setdefault(stream_id, [])
+                elif isinstance(ev, (h2.events.DataReceived, h2.events.StreamEnded)):
+                    stream_evmap.setdefault(ev.stream_id, []).append(ev)
+                elif isinstance(ev, h2.events.ConnectionTerminated):
                     raise ConnectionClosed
-                elif isinstance(event, h2.events.DataReceived):
-                    # If body arrives before we try to read it, ack to free window
-                    h.c.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
-                # Other events can be safely ignored for minimal server
-                i += 1
+                elif isinstance(ev, h2.events.RemoteSettingsChanged):
+                    # ignore
+                    pass
+                elif isinstance(ev, h2.events.SettingsAcknowledged):
+                    # ignore
+                    pass
+                else:
+                    # ignore other events
+                    pass
+
+            # Serve each new request detected in this batch synchronously.
+            for sid in stream_order:
+                h.call_wsgi_on_stream(app, sid, stream_headers[sid], initial_events=stream_evmap.get(sid, []))  # type: ignore[arg-type]
+
             h._send_outbound()
         except socket.timeout:
             continue

--- a/src/zibai/h2.py
+++ b/src/zibai/h2.py
@@ -164,6 +164,8 @@ class H2Protocol:
                 if k in {b"connection", b"transfer-encoding"}:
                     continue
                 headers.append((k, v))
+            # debug
+            print('[h2] sending headers', headers)
             self.c.send_headers(stream_id, headers, end_stream=False)
             header_sent["value"] = True
             self._send_outbound()
@@ -221,50 +223,50 @@ class H2Protocol:
         *,
         initial_events: list[Any] | None = None,
     ) -> None:
-        # Read the entire request body for this stream before invoking WSGI.
-        body_chunks: list[bytes] = []
+        # Lazily read request body when the app asks for it
+        pending_eom = {"value": False}
 
-        def consume_events(evts: list[Any]) -> bool:
-            ended = False
+        def prime_events(evts: list[Any]) -> None:
             for event in evts:
-                debug_logger.debug("[h2] body pre-consume event: %r", event)
                 if isinstance(event, h2.events.DataReceived) and event.stream_id == stream_id:
-                    body_chunks.append(event.data)
-                    self.c.acknowledge_received_data(
-                        event.flow_controlled_length, event.stream_id
-                    )
+                    # Stash into a simple buffer the next call will use
+                    data_buffer.extend(event.data)
+                    self.c.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
                 if isinstance(event, h2.events.StreamEnded) and event.stream_id == stream_id:
-                    ended = True
+                    pending_eom["value"] = True
             self._send_outbound()
-            return ended
 
+        data_buffer = bytearray()
         if initial_events:
-            ended = consume_events(initial_events)
-            initial_events = []
-        else:
-            ended = False
-        while not ended:
-            try:
-                data = self.s.recv(65535)
-            except socket.timeout:
-                continue
-            if not data:
-                break
-            events = self.c.receive_data(data)
-            ended = consume_events(events)
-
-        # Build environ with a static input source
-        environ = self._build_environ(headers)
-
-        buffer = bytearray(b"".join(body_chunks))
+            prime_events(initial_events)
 
         def receive_body() -> bytes:
-            if not buffer:
+            if pending_eom["value"] and not data_buffer:
                 return b""
-            data = bytes(buffer)
-            buffer.clear()
-            return data
+            if data_buffer:
+                chunk = bytes(data_buffer)
+                data_buffer.clear()
+                return chunk
+            while True:
+                try:
+                    data = self.s.recv(65535)
+                except socket.timeout:
+                    return b""
+                if not data:
+                    pending_eom["value"] = True
+                    return b""
+                for event in self.c.receive_data(data):
+                    if isinstance(event, h2.events.DataReceived) and event.stream_id == stream_id:
+                        self.c.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
+                        self._send_outbound()
+                        return event.data
+                    if isinstance(event, h2.events.StreamEnded) and event.stream_id == stream_id:
+                        pending_eom["value"] = True
+                        self._send_outbound()
+                        return b""
+                self._send_outbound()
 
+        environ = self._build_environ(headers)
         environ["wsgi.input"] = Input(receive_body)
 
         start_response = self._start_response_factory(stream_id)
@@ -273,26 +275,29 @@ class H2Protocol:
             iterable = wsgi_app(environ, start_response)
             iterator = iter(iterable)
 
-            # Ensure headers are sent before body
-            start_response._send_headers_if_needed()  # type: ignore[attr-defined]
-
             try:
                 first_chunk = next(iterator)
             except StopIteration:
                 first_chunk = b""
 
+            # Ensure headers are sent after start_response is called by the app
+            start_response._send_headers_if_needed()  # type: ignore[attr-defined]
+
             status_code = start_response._response_buffer["status"]  # type: ignore[attr-defined]
             log_http(environ, int(status_code))
 
             if first_chunk:
+                print('[h2] sending first chunk', len(first_chunk))
                 self._send_data_with_flow_control(stream_id, first_chunk, end_stream=False)
 
             for chunk in iterator:
                 if not chunk:
                     continue
+                print('[h2] sending chunk', len(chunk))
                 self._send_data_with_flow_control(stream_id, chunk, end_stream=False)
 
             # End stream
+            print('[h2] end stream')
             self._send_data_with_flow_control(stream_id, b"", end_stream=True)
         except BaseException:
             error_logger.exception("Error while calling WSGI application", exc_info=sys.exc_info())
@@ -364,11 +369,13 @@ def http2_protocol(
             if not data:
                 raise ConnectionClosed
             events = h.c.receive_data(data)
+            print('[h2] got events:', [e.__class__.__name__ for e in events])
             i = 0
             while i < len(events):
                 event = events[i]
                 debug_logger.debug("[h2] recv event from %s:%d: %r", *h.peername, event)
                 if isinstance(event, h2.events.RequestReceived):
+                    print('[h2] RequestReceived, stream', event.stream_id)
                     # Collect any remaining events from this batch for this stream
                     remaining = events[i + 1 :]
                     h.call_wsgi_on_stream(app, event.stream_id, event.headers, initial_events=remaining)  # type: ignore[arg-type]

--- a/src/zibai/h2.py
+++ b/src/zibai/h2.py
@@ -120,7 +120,7 @@ class H2Protocol:
         environ["PATH_INFO"] = path_info
         environ["QUERY_STRING"] = query
 
-        return environ  # type: ignore
+        return environ
 
     def _start_response_factory(
         self, stream_id: int

--- a/src/zibai/h2.py
+++ b/src/zibai/h2.py
@@ -1,0 +1,354 @@
+import socket
+import sys
+import threading
+from typing import Any, Callable
+
+import h2.connection
+import h2.events
+from h2.settings import SettingCodes
+
+from .const import SERVER_NAME
+from .logger import debug_logger, error_logger, log_http
+from .utils import Input
+from .wsgi_typing import Environ, ExceptionInfo, WSGIApp
+
+
+H2_CLIENT_PREFACE = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+
+
+class ConnectionClosed(Exception):
+    pass
+
+
+class H2Protocol:
+    def __init__(
+        self,
+        *,
+        sock: socket.socket,
+        peername: tuple[str, int],
+        sockname: tuple[str, int],
+        graceful_exit: threading.Event,
+        url_scheme: str,
+        script_name: str,
+    ) -> None:
+        self.s = sock
+        self.peername = peername
+        self.sockname = sockname
+        self.graceful_exit = graceful_exit
+        self.url_scheme = url_scheme
+        self.script_name = script_name
+
+        self.c = h2.connection.H2Connection(client_side=False)
+
+    def _send_outbound(self) -> None:
+        data = self.c.data_to_send()
+        if data:
+            self.s.sendall(data)
+
+    def _discard_client_preface(self) -> None:
+        # The client preface must be consumed by the server.
+        preface = self.s.recv(len(H2_CLIENT_PREFACE))
+        if preface != H2_CLIENT_PREFACE:
+            # If it doesn't match, raise to fallback logic.
+            raise ConnectionClosed
+
+    def _build_environ(self, headers: list[tuple[bytes, bytes]]) -> Environ:
+        method = "GET"
+        path = "/"
+        query = ""
+        http_scheme = self.url_scheme
+
+        server_name, server_port = self.sockname
+        remote_name, remote_port = self.peername
+
+        environ: Environ = {
+            "REQUEST_METHOD": method,
+            "SCRIPT_NAME": self.script_name,
+            "SERVER_NAME": server_name,
+            "SERVER_PORT": str(server_port),
+            "REMOTE_ADDR": remote_name,
+            "REMOTE_PORT": str(remote_port),
+            "REQUEST_URI": "",
+            "PATH_INFO": "",
+            "QUERY_STRING": "",
+            "SERVER_PROTOCOL": "HTTP/2.0",
+            "wsgi.version": (1, 0),
+            "wsgi.url_scheme": http_scheme,
+            # wsgi.input filled later
+            "wsgi.input": Input(lambda: b""),
+            "wsgi.errors": sys.stderr,
+            "wsgi.multithread": True,
+            "wsgi.multiprocess": True,
+            "wsgi.run_once": False,
+        }
+
+        for name, value in headers:
+            n = name.decode("latin1")
+            v = value.decode("latin1")
+            if n == ":method":
+                method = v
+                environ["REQUEST_METHOD"] = method
+            elif n == ":path":
+                if "?" in v:
+                    path, query = v.split("?", 1)
+                else:
+                    path, query = v, ""
+                environ["REQUEST_URI"] = v
+            elif n == ":scheme":
+                http_scheme = v
+                environ["wsgi.url_scheme"] = http_scheme
+            elif n == "content-type":
+                environ["CONTENT_TYPE"] = v
+            elif n == "content-length":
+                environ["CONTENT_LENGTH"] = v
+            else:
+                if not n.startswith(":"):
+                    http_name = "HTTP_" + n.upper().replace("-", "_")
+                    if http_name not in environ:
+                        environ[http_name] = v
+                    else:
+                        environ[http_name] += "," + v
+
+        # SCRIPT_NAME and PATH_INFO handling
+        environ["SCRIPT_NAME"] = self.script_name
+        if path == self.script_name:
+            path_info = ""
+        else:
+            url_prefix_with_trailing_slash = self.script_name + "/"
+            if path.startswith(url_prefix_with_trailing_slash):
+                path_info = path[len(self.script_name) :]
+            else:
+                path_info = path
+        environ["PATH_INFO"] = path_info
+        environ["QUERY_STRING"] = query
+
+        return environ  # type: ignore
+
+    def _start_response_factory(
+        self, stream_id: int
+    ) -> Callable[[str, list[tuple[str, str]], ExceptionInfo | None], Callable[[bytes], Any]]:
+        header_sent = {"value": False}
+        response_buffer: dict[str, Any] = {"status": 200, "headers": []}
+
+        def start_response(
+            status: str,
+            headers: list[tuple[str, str]],
+            exc_info: ExceptionInfo | None = None,
+        ) -> Callable[[bytes], Any]:
+            if exc_info is not None and header_sent["value"]:
+                raise exc_info[1].with_traceback(exc_info[2])
+            if header_sent["value"]:
+                raise RuntimeError("start_response() was already called")
+
+            status_code_str, _ = status.split(" ", 1)
+            if not status_code_str.isdigit():
+                raise RuntimeError(f"Invalid status: {status}")
+            response_buffer["status"] = int(status_code_str)
+
+            # Normalize headers to lowercase, add server
+            norm_headers = [(k.lower(), v) for k, v in headers]
+            norm_headers.append(("server", SERVER_NAME.decode("latin1")))
+            response_buffer["headers"] = norm_headers
+
+            def write(chunk: bytes) -> None:
+                # This write callable is rarely used; we'll send in the response loop.
+                self._send_data_with_flow_control(stream_id, chunk, end_stream=False)
+
+            return write
+
+        def _send_headers_if_needed() -> None:
+            if header_sent["value"]:
+                return
+            # Build HTTP/2 headers
+            headers = [(":status", str(response_buffer["status"]))]
+            for k, v in response_buffer["headers"]:
+                # Exclude hop-by-hop headers automatically ignored in h2
+                if k.lower() in {"connection", "transfer-encoding"}:
+                    continue
+                headers.append((k, v))
+            self.c.send_headers(stream_id, headers, end_stream=False)
+            header_sent["value"] = True
+            self._send_outbound()
+
+        # Attach helper to the instance for later use within call_wsgi
+        start_response._send_headers_if_needed = _send_headers_if_needed  # type: ignore[attr-defined]
+        start_response._response_buffer = response_buffer  # type: ignore[attr-defined]
+        start_response._header_sent = header_sent  # type: ignore[attr-defined]
+        return start_response
+
+    def _send_data_with_flow_control(
+        self, stream_id: int, data: bytes, *, end_stream: bool
+    ) -> None:
+        idx = 0
+        while idx < len(data) or (len(data) == 0 and end_stream):
+            window = min(
+                self.c.local_flow_control_window(stream_id),
+                self.c.max_outbound_frame_size,
+            )
+            if window <= 0:
+                # Wait for window update by reading peer frames
+                self._recv_and_handle_events(block_until_window_for=stream_id)
+                continue
+
+            to_send = data[idx : idx + window]
+            idx += len(to_send)
+            # Only mark end_stream if this is the last piece
+            self.c.send_data(stream_id, to_send, end_stream=end_stream and idx >= len(data))
+            self._send_outbound()
+            if len(to_send) == 0:
+                # End stream with empty data
+                break
+
+    def _recv_and_handle_events(self, *, block_until_window_for: int | None = None) -> None:
+        # Minimal event handling to advance flow control; does not process new requests here.
+        data = self.s.recv(65535)
+        if not data:
+            raise ConnectionClosed
+        for event in self.c.receive_data(data):
+            debug_logger.debug("[h2] recv event from %s:%d: %r", *self.peername, event)
+            if isinstance(event, h2.events.DataReceived):
+                # Acknowledge any inbound data to release connection window
+                self.c.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
+            # Send any pending ACKs or settings
+        self._send_outbound()
+
+    def call_wsgi_on_stream(
+        self, wsgi_app: WSGIApp, stream_id: int, headers: list[tuple[bytes, bytes]]
+    ) -> None:
+        # Build environ and set wsgi.input to read from this stream lazily.
+        # We will read Data frames synchronously from the connection as the app requests body.
+        pending_eom = {"value": False}
+
+        def receive_body() -> bytes:
+            if pending_eom["value"]:
+                return b""
+            # Read events until we get data or end of stream for this stream
+            while True:
+                data = self.s.recv(65535)
+                if not data:
+                    pending_eom["value"] = True
+                    return b""
+                for event in self.c.receive_data(data):
+                    debug_logger.debug(
+                        "[h2] recv body event from %s:%d: %r", *self.peername, event
+                    )
+                    if isinstance(event, h2.events.DataReceived) and event.stream_id == stream_id:
+                        self.c.acknowledge_received_data(
+                            event.flow_controlled_length, event.stream_id
+                        )
+                        self._send_outbound()
+                        return event.data
+                    if isinstance(event, h2.events.StreamEnded) and event.stream_id == stream_id:
+                        pending_eom["value"] = True
+                        self._send_outbound()
+                        return b""
+                self._send_outbound()
+
+        environ = self._build_environ(headers)
+        environ["wsgi.input"] = Input(receive_body)
+
+        start_response = self._start_response_factory(stream_id)
+        iterable = None
+        status_code = 500
+
+        try:
+            iterable = wsgi_app(environ, start_response)
+            iterator = iter(iterable)
+
+            # Ensure headers are sent before body
+            start_response._send_headers_if_needed()  # type: ignore[attr-defined]
+
+            try:
+                first_chunk = next(iterator)
+            except StopIteration:
+                first_chunk = b""
+
+            status_code = start_response._response_buffer["status"]  # type: ignore[attr-defined]
+            log_http(environ, int(status_code))
+
+            if first_chunk:
+                self._send_data_with_flow_control(stream_id, first_chunk, end_stream=False)
+
+            for chunk in iterator:
+                if not chunk:
+                    continue
+                self._send_data_with_flow_control(stream_id, chunk, end_stream=False)
+
+            # End stream
+            self._send_data_with_flow_control(stream_id, b"", end_stream=True)
+        except BaseException:
+            error_logger.exception("Error while calling WSGI application", exc_info=sys.exc_info())
+            # Send 500 if headers not sent
+            # Build minimal 500 response
+            headers = [(":status", "500"), ("content-type", "text/plain; charset=utf-8"), ("content-length", "21"), ("server", SERVER_NAME.decode("latin1"))]
+            try:
+                self.c.send_headers(stream_id, headers, end_stream=False)
+                self._send_data_with_flow_control(stream_id, b"Internal Server Error", end_stream=True)
+                self._send_outbound()
+            except Exception:
+                pass
+            log_http(environ, 500)
+            raise
+        finally:
+            close = getattr(iterable, "close", None)
+            if callable(close):
+                close()
+
+
+def http2_protocol(
+    app: WSGIApp,
+    sock: socket.socket,
+    graceful_exit: threading.Event,
+    *,
+    url_scheme: str = "http",
+    script_name: str = "",
+) -> None:
+    peername = sock.getpeername()
+    if isinstance(peername, str):
+        peername = (peername, 0)
+    else:
+        peername = peername[:2]
+    sockname = sock.getsockname()
+    if isinstance(sockname, str):
+        sockname = (sockname, 0)
+    else:
+        sockname = sockname[:2]
+
+    h = H2Protocol(
+        sock=sock,
+        peername=peername,
+        sockname=sockname,
+        graceful_exit=graceful_exit,
+        url_scheme=url_scheme,
+        script_name=script_name,
+    )
+
+    # Consume client preface and send our settings
+    h._discard_client_preface()
+    h.c.initiate_connection()
+    # Restrict to one concurrent stream to simplify processing
+    h.c.update_settings({SettingCodes.MAX_CONCURRENT_STREAMS: 1})
+    h._send_outbound()
+
+    while not graceful_exit.is_set():
+        try:
+            data = sock.recv(65535)
+            if not data:
+                raise ConnectionClosed
+            events = h.c.receive_data(data)
+            for event in events:
+                debug_logger.debug("[h2] recv event from %s:%d: %r", *h.peername, event)
+                if isinstance(event, h2.events.RequestReceived):
+                    # Serve this request synchronously on this connection
+                    h.call_wsgi_on_stream(app, event.stream_id, event.headers)  # type: ignore[arg-type]
+                elif isinstance(event, h2.events.ConnectionTerminated):
+                    raise ConnectionClosed
+                elif isinstance(event, h2.events.DataReceived):
+                    # If body arrives before we try to read it, ack to free window
+                    h.c.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
+                # Other events can be safely ignored for minimal server
+            h._send_outbound()
+        except (ConnectionClosed, ConnectionError, OSError):
+            debug_logger.debug("[h2] Connection closed by %s:%d", *h.peername)
+            break
+

--- a/src/zibai/h2.py
+++ b/src/zibai/h2.py
@@ -6,6 +6,7 @@ from typing import Any, Callable
 import h2.connection
 import h2.events
 from h2.settings import SettingCodes
+from h2.config import H2Configuration
 
 from .const import SERVER_NAME
 from .logger import debug_logger, error_logger, log_http
@@ -38,22 +39,14 @@ class H2Protocol:
         self.url_scheme = url_scheme
         self.script_name = script_name
 
-        self.c = h2.connection.H2Connection(client_side=False)
+        self.c = h2.connection.H2Connection(config=H2Configuration(client_side=False))
 
     def _send_outbound(self) -> None:
         data = self.c.data_to_send()
         if data:
             self.s.sendall(data)
 
-    def _discard_client_preface(self) -> None:
-        # Consume exactly the length of the HTTP/2 client preface.
-        need = len(H2_CLIENT_PREFACE)
-        received = 0
-        while received < need:
-            chunk = self.s.recv(need - received)
-            if not chunk:
-                raise ConnectionClosed
-            received += len(chunk)
+    # No explicit preface discard: pass the preface to h2 via receive_data
 
     def _build_environ(self, headers: list[tuple[bytes, bytes]]) -> Environ:
         method = "GET"
@@ -148,9 +141,11 @@ class H2Protocol:
                 raise RuntimeError(f"Invalid status: {status}")
             response_buffer["status"] = int(status_code_str)
 
-            # Normalize headers to lowercase, add server
-            norm_headers = [(k.lower(), v) for k, v in headers]
-            norm_headers.append(("server", SERVER_NAME.decode("latin1")))
+            # Normalize headers to lowercase, encode to bytes, add server
+            norm_headers = [
+                (k.lower().encode("latin1"), v.encode("latin1")) for k, v in headers
+            ]
+            norm_headers.append((b"server", SERVER_NAME))
             response_buffer["headers"] = norm_headers
 
             def write(chunk: bytes) -> None:
@@ -163,10 +158,10 @@ class H2Protocol:
             if header_sent["value"]:
                 return
             # Build HTTP/2 headers
-            headers = [(":status", str(response_buffer["status"]))]
+            headers = [(b":status", str(response_buffer["status"]).encode("ascii"))]
             for k, v in response_buffer["headers"]:
                 # Exclude hop-by-hop headers automatically ignored in h2
-                if k.lower() in {"connection", "transfer-encoding"}:
+                if k in {b"connection", b"transfer-encoding"}:
                     continue
                 headers.append((k, v))
             self.c.send_headers(stream_id, headers, end_stream=False)
@@ -303,10 +298,10 @@ class H2Protocol:
             error_logger.exception("Error while calling WSGI application", exc_info=sys.exc_info())
             # Send 500 if headers not sent
             headers = [
-                (":status", "500"),
-                ("content-type", "text/plain; charset=utf-8"),
-                ("content-length", "21"),
-                ("server", SERVER_NAME.decode("latin1")),
+                (b":status", b"500"),
+                (b"content-type", b"text/plain; charset=utf-8"),
+                (b"content-length", b"21"),
+                (b"server", SERVER_NAME),
             ]
             try:
                 self.c.send_headers(stream_id, headers, end_stream=False)
@@ -330,28 +325,33 @@ def http2_protocol(
     url_scheme: str = "http",
     script_name: str = "",
 ) -> None:
-    peername = sock.getpeername()
-    if isinstance(peername, str):
-        peername = (peername, 0)
-    else:
-        peername = peername[:2]
-    sockname = sock.getsockname()
-    if isinstance(sockname, str):
-        sockname = (sockname, 0)
-    else:
-        sockname = sockname[:2]
+    # Enter HTTP/2 (h2c) handler
+    try:
+        peername = sock.getpeername()
+        if isinstance(peername, str):
+            peername = (peername, 0)
+        else:
+            peername = peername[:2]
+        sockname = sock.getsockname()
+        if isinstance(sockname, str):
+            sockname = (sockname, 0)
+        else:
+            sockname = sockname[:2]
 
-    h = H2Protocol(
-        sock=sock,
-        peername=peername,
-        sockname=sockname,
-        graceful_exit=graceful_exit,
-        url_scheme=url_scheme,
-        script_name=script_name,
-    )
+        h = H2Protocol(
+            sock=sock,
+            peername=peername,
+            sockname=sockname,
+            graceful_exit=graceful_exit,
+            url_scheme=url_scheme,
+            script_name=script_name,
+        )
+    except Exception:
+        import traceback
+        traceback.print_exc()
+        return
 
-    # Consume client preface and send our settings
-    h._discard_client_preface()
+    # Send our initial SETTINGS; we'll pass the client's preface to receive_data
     h.c.initiate_connection()
     # Restrict to one concurrent stream to simplify processing
     h.c.update_settings({SettingCodes.MAX_CONCURRENT_STREAMS: 1})

--- a/src/zibai/h2.py
+++ b/src/zibai/h2.py
@@ -167,7 +167,7 @@ class H2Protocol:
                     continue
                 headers.append((k, v))
             # debug
-            print('[h2] sending headers', headers)
+            debug_logger.debug("[h2] sending headers: %r", headers)
             with self.send_lock:
                 self.c.send_headers(stream_id, headers, end_stream=False)
                 data_to_send = self.c.data_to_send()
@@ -300,17 +300,17 @@ class H2Protocol:
             log_http(environ, int(status_code))
 
             if first_chunk:
-                print('[h2] sending first chunk', len(first_chunk))
+                debug_logger.debug("[h2] sending first chunk: %d", len(first_chunk))
                 self._send_data_with_flow_control(stream_id, first_chunk, end_stream=False)
 
             for chunk in iterator:
                 if not chunk:
                     continue
-                print('[h2] sending chunk', len(chunk))
+                debug_logger.debug("[h2] sending chunk: %d", len(chunk))
                 self._send_data_with_flow_control(stream_id, chunk, end_stream=False)
 
             # End stream
-            print('[h2] end stream')
+            debug_logger.debug("[h2] end stream")
             self._send_data_with_flow_control(stream_id, b"", end_stream=True)
         except BaseException:
             error_logger.exception("Error while calling WSGI application", exc_info=sys.exc_info())

--- a/src/zibai/h2.py
+++ b/src/zibai/h2.py
@@ -41,6 +41,8 @@ class H2Protocol:
 
         self.c = h2.connection.H2Connection(config=H2Configuration(client_side=False))
         self.send_lock = threading.Lock()
+        self._pending_events: dict[int, list[Any]] = {}
+        self._pending_lock = threading.Lock()
 
     def _send_outbound(self) -> None:
         with self.send_lock:
@@ -220,6 +222,8 @@ class H2Protocol:
             if isinstance(event, h2.events.DataReceived):
                 # Acknowledge any inbound data to release connection window
                 self.c.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
+                with self._pending_lock:
+                    self._pending_events.setdefault(event.stream_id, []).append(event)
             # Send any pending ACKs or settings
         self._send_outbound()
 
@@ -249,6 +253,14 @@ class H2Protocol:
             prime_events(initial_events)
 
         def receive_body() -> bytes:
+            with self._pending_lock:
+                pending = self._pending_events.pop(stream_id, [])
+            if pending:
+                prime_events(pending)
+                if data_buffer:
+                    chunk0 = bytes(data_buffer)
+                    data_buffer.clear()
+                    return chunk0
             if pending_eom["value"] and not data_buffer:
                 return b""
             if data_buffer:
@@ -268,6 +280,11 @@ class H2Protocol:
                     if isinstance(event, h2.events.DataReceived) and event.stream_id == stream_id:
                         data_buffer.extend(event.data)
                         self.c.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
+                    elif isinstance(event, h2.events.DataReceived):
+                        # queue data for other streams
+                        self.c.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
+                        with self._pending_lock:
+                            self._pending_events.setdefault(event.stream_id, []).append(event)
                     if isinstance(event, h2.events.StreamEnded) and event.stream_id == stream_id:
                         pending_eom["value"] = True
                 self._send_outbound()
@@ -371,8 +388,8 @@ def http2_protocol(
 
     # Send our initial SETTINGS; we'll pass the client's preface to receive_data
     h.c.initiate_connection()
-    # Restrict to one concurrent stream to simplify processing
-    h.c.update_settings({SettingCodes.MAX_CONCURRENT_STREAMS: 1})
+    # Allow multiple concurrent inbound streams for a single TCP connection
+    h.c.update_settings({SettingCodes.MAX_CONCURRENT_STREAMS: 100})
     h._send_outbound()
 
     sock.settimeout(1)

--- a/src/zibai/h2.py
+++ b/src/zibai/h2.py
@@ -259,19 +259,24 @@ class H2Protocol:
                 try:
                     data = self.s.recv(65535)
                 except socket.timeout:
-                    return b""
+                    continue
                 if not data:
                     pending_eom["value"] = True
                     return b""
-                for event in self.c.receive_data(data):
+                events = self.c.receive_data(data)
+                for event in events:
                     if isinstance(event, h2.events.DataReceived) and event.stream_id == stream_id:
+                        data_buffer.extend(event.data)
                         self.c.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
-                        self._send_outbound()
-                        return event.data
                     if isinstance(event, h2.events.StreamEnded) and event.stream_id == stream_id:
                         pending_eom["value"] = True
-                        self._send_outbound()
-                        return b""
+                self._send_outbound()
+                if data_buffer:
+                    chunk = bytes(data_buffer)
+                    data_buffer.clear()
+                    return chunk
+                if pending_eom["value"]:
+                    return b""
                 self._send_outbound()
 
         environ = self._build_environ(headers)

--- a/tests/test_h2.py
+++ b/tests/test_h2.py
@@ -30,6 +30,32 @@ def echo_app(environ, start_response):
             return
 
 
+def method_app(environ, start_response):
+    method = environ["REQUEST_METHOD"].upper()
+    if method == "HEAD":
+        start_response("200 OK", [("Content-Length", "12")])
+        return [b""]
+    if method == "OPTIONS":
+        start_response(
+            "204 No Content",
+            [("Allow", "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"), ("Content-Length", "0")],
+        )
+        return [b""]
+    if method in {"GET", "DELETE"}:
+        start_response("200 OK", [("Content-Length", "0")])
+        return [b""]
+    if method in {"POST", "PUT", "PATCH"}:
+        # echo
+        start_response("200 OK", [])
+        for chunk in environ["wsgi.input"]:
+            if chunk:
+                yield chunk
+            else:
+                return
+    start_response("405 Method Not Allowed", [("Content-Length", "0")])
+    return [b""]
+
+
 @pytest.mark.parametrize("backlog", [10, None])
 def test_h2c_hello_world(
     socket_and_event: tuple[socket.socket, threading.Event], backlog: int | None

--- a/tests/test_h2.py
+++ b/tests/test_h2.py
@@ -1,0 +1,192 @@
+import socket
+import threading
+import time
+
+import h2.connection
+import h2.events
+import pytest
+
+from zibai.core import serve
+
+
+def hello_world_app(environ, start_response):
+    start_response(
+        "200 OK",
+        [
+            ("Content-type", "text/plain; charset=utf-8"),
+            ("Content-Length", "12"),
+        ],
+    )
+    return [b"Hello World!"]
+
+
+def echo_app(environ, start_response):
+    start_response("200 OK", [])
+    # Stream back whatever the client sends
+    for chunk in environ["wsgi.input"]:
+        if chunk:
+            yield chunk
+        else:
+            return
+
+
+@pytest.mark.parametrize("backlog", [10, None])
+def test_h2c_hello_world(
+    socket_and_event: tuple[socket.socket, threading.Event], backlog: int | None
+) -> None:
+    bind_socket, exit_event = socket_and_event
+    if backlog is None:
+        bind_socket.listen()
+    else:
+        bind_socket.listen(backlog)
+
+    server_thread = threading.Thread(
+        target=serve,
+        kwargs=dict(
+            app=hello_world_app,
+            bind_sockets=[bind_socket],
+            max_workers=10,
+            graceful_exit=exit_event,
+        ),
+        daemon=True,
+    )
+    server_thread.start()
+
+    time.sleep(1)
+
+    client_socket = socket.socket(
+        bind_socket.family, bind_socket.type, bind_socket.proto
+    )
+    client_socket.connect(bind_socket.getsockname())
+    with client_socket:
+        conn = h2.connection.H2Connection()
+        conn.initiate_connection()
+        # Send client connection preface and initial settings
+        data = conn.data_to_send()
+        assert data.startswith(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+        client_socket.sendall(data)
+
+        # Open a stream with GET /
+        stream_id = conn.get_next_available_stream_id()
+        conn.send_headers(
+            stream_id,
+            [
+                (":method", "GET"),
+                (":authority", "example.com"),
+                (":scheme", "http"),
+                (":path", "/"),
+            ],
+            end_stream=True,
+        )
+        client_socket.sendall(conn.data_to_send())
+
+        # Receive response
+        body = b""
+        status = None
+        while True:
+            data = client_socket.recv(65535)
+            assert data
+            events = conn.receive_data(data)
+            for event in events:
+                if isinstance(event, h2.events.ResponseReceived):
+                    for n, v in event.headers:
+                        if n == ":status":
+                            status = int(v)
+                if isinstance(event, h2.events.DataReceived):
+                    body += event.data
+                    conn.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
+                if isinstance(event, h2.events.StreamEnded):
+                    break
+            client_socket.sendall(conn.data_to_send())
+            if any(isinstance(e, h2.events.StreamEnded) for e in events):
+                break
+
+        assert status == 200
+        assert body == b"Hello World!"
+
+
+def test_h2c_post_echo(socket_and_event: tuple[socket.socket, threading.Event]) -> None:
+    bind_socket, exit_event = socket_and_event
+    bind_socket.listen()
+
+    server_thread = threading.Thread(
+        target=serve,
+        kwargs=dict(
+            app=echo_app,
+            bind_sockets=[bind_socket],
+            max_workers=10,
+            graceful_exit=exit_event,
+        ),
+        daemon=True,
+    )
+    server_thread.start()
+
+    time.sleep(1)
+
+    client_socket = socket.socket(
+        bind_socket.family, bind_socket.type, bind_socket.proto
+    )
+    client_socket.connect(bind_socket.getsockname())
+    with client_socket:
+        conn = h2.connection.H2Connection()
+        conn.initiate_connection()
+        client_socket.sendall(conn.data_to_send())
+
+        stream_id = conn.get_next_available_stream_id()
+        conn.send_headers(
+            stream_id,
+            [
+                (":method", "POST"),
+                (":authority", "example.com"),
+                (":scheme", "http"),
+                (":path", "/echo"),
+                ("content-type", "text/plain"),
+            ],
+            end_stream=False,
+        )
+        payload = b"chunk1-" + b"x" * 1024 + b"-chunk2"
+        # Send request body possibly split by flow control
+        idx = 0
+        while idx < len(payload):
+            window = min(
+                conn.local_flow_control_window(stream_id), conn.max_outbound_frame_size
+            )
+            if window == 0:
+                # Need to read WINDOW_UPDATE
+                data = client_socket.recv(65535)
+                assert data
+                events = conn.receive_data(data)
+                client_socket.sendall(conn.data_to_send())
+                continue
+            to_send = payload[idx : idx + window]
+            idx += len(to_send)
+            conn.send_data(stream_id, to_send, end_stream=False)
+            client_socket.sendall(conn.data_to_send())
+
+        conn.end_stream(stream_id)
+        client_socket.sendall(conn.data_to_send())
+
+        # Receive echoed body
+        received = b""
+        status = None
+        while True:
+            data = client_socket.recv(65535)
+            assert data
+            events = conn.receive_data(data)
+            for event in events:
+                if isinstance(event, h2.events.ResponseReceived):
+                    for n, v in event.headers:
+                        if n == ":status":
+                            status = int(v)
+                if isinstance(event, h2.events.DataReceived):
+                    received += event.data
+                    conn.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
+                if isinstance(event, h2.events.StreamEnded):
+                    break
+            client_socket.sendall(conn.data_to_send())
+            if any(isinstance(e, h2.events.StreamEnded) for e in events):
+                break
+
+        assert status == 200
+        assert received == payload
+

--- a/tests/test_h2.py
+++ b/tests/test_h2.py
@@ -90,8 +90,11 @@ def test_h2c_hello_world(
             for event in events:
                 if isinstance(event, h2.events.ResponseReceived):
                     for n, v in event.headers:
-                        if n == ":status":
-                            status = int(v)
+                        if n in (":status", b":status"):
+                            if isinstance(v, bytes):
+                                status = int(v.decode("ascii"))
+                            else:
+                                status = int(v)
                 if isinstance(event, h2.events.DataReceived):
                     body += event.data
                     conn.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
@@ -176,8 +179,11 @@ def test_h2c_post_echo(socket_and_event: tuple[socket.socket, threading.Event]) 
             for event in events:
                 if isinstance(event, h2.events.ResponseReceived):
                     for n, v in event.headers:
-                        if n == ":status":
-                            status = int(v)
+                        if n in (":status", b":status"):
+                            if isinstance(v, bytes):
+                                status = int(v.decode("ascii"))
+                            else:
+                                status = int(v)
                 if isinstance(event, h2.events.DataReceived):
                     received += event.data
                     conn.acknowledge_received_data(event.flow_controlled_length, event.stream_id)

--- a/tests/test_h2_concurrency.py
+++ b/tests/test_h2_concurrency.py
@@ -10,11 +10,12 @@ from zibai.core import serve
 
 def streaming_echo_app(environ, start_response):
     start_response("200 OK", [])
-    for chunk in environ["wsgi.input"]:
-        if chunk:
-            yield chunk
-        else:
-            return
+    input_stream = environ["wsgi.input"]
+    while True:
+        data = input_stream.read(64 * 1024)
+        if not data:
+            break
+        yield data
 
 
 def test_h2c_concurrent_streams(socket_and_event):

--- a/tests/test_h2_concurrency.py
+++ b/tests/test_h2_concurrency.py
@@ -1,0 +1,95 @@
+import socket
+import threading
+import time
+
+import h2.connection
+import h2.events
+
+from zibai.core import serve
+
+
+def streaming_echo_app(environ, start_response):
+    start_response("200 OK", [])
+    for chunk in environ["wsgi.input"]:
+        if chunk:
+            yield chunk
+        else:
+            return
+
+
+def test_h2c_concurrent_streams(socket_and_event):
+    bind_socket, exit_event = socket_and_event
+    bind_socket.listen()
+
+    server_thread = threading.Thread(
+        target=serve,
+        kwargs=dict(
+            app=streaming_echo_app,
+            bind_sockets=[bind_socket],
+            max_workers=10,
+            graceful_exit=exit_event,
+        ),
+        daemon=True,
+    )
+    server_thread.start()
+    time.sleep(0.5)
+
+    client_socket = socket.socket(bind_socket.family, bind_socket.type, bind_socket.proto)
+    client_socket.connect(bind_socket.getsockname())
+    with client_socket:
+        conn = h2.connection.H2Connection()
+        conn.initiate_connection()
+        client_socket.sendall(conn.data_to_send())
+
+        # Open three streams interleaved
+        s1, s2, s3 = conn.get_next_available_stream_id(), None, None
+        conn.send_headers(s1, [(":method", "POST"), (":authority", "x"), (":scheme", "http"), (":path", "/")], end_stream=False)
+        client_socket.sendall(conn.data_to_send())
+
+        s2 = conn.get_next_available_stream_id()
+        conn.send_headers(s2, [(":method", "POST"), (":authority", "x"), (":scheme", "http"), (":path", "/")], end_stream=False)
+        client_socket.sendall(conn.data_to_send())
+
+        # send partial bodies interleaved
+        conn.send_data(s1, b"A" * 1024, end_stream=False)
+        client_socket.sendall(conn.data_to_send())
+        conn.send_data(s2, b"B" * 2048, end_stream=False)
+        client_socket.sendall(conn.data_to_send())
+
+        s3 = conn.get_next_available_stream_id()
+        conn.send_headers(s3, [(":method", "POST"), (":authority", "x"), (":scheme", "http"), (":path", "/")], end_stream=False)
+        client_socket.sendall(conn.data_to_send())
+        conn.send_data(s3, b"C" * 512, end_stream=True)
+        client_socket.sendall(conn.data_to_send())
+
+        # finish s1 and s2
+        conn.send_data(s1, b"A" * 512, end_stream=True)
+        client_socket.sendall(conn.data_to_send())
+        conn.send_data(s2, b"B" * 256, end_stream=True)
+        client_socket.sendall(conn.data_to_send())
+
+        results = {s1: b"", s2: b"", s3: b""}
+        statuses = {}
+
+        ended = set()
+        while len(ended) < 3:
+            data = client_socket.recv(65535)
+            assert data
+            events = conn.receive_data(data)
+            for ev in events:
+                if isinstance(ev, h2.events.ResponseReceived):
+                    for n, v in ev.headers:
+                        if n in (":status", b":status"):
+                            statuses[ev.stream_id] = int(v if isinstance(v, str) else v.decode("ascii"))
+                if isinstance(ev, h2.events.DataReceived):
+                    results[ev.stream_id] += ev.data
+                    conn.acknowledge_received_data(ev.flow_controlled_length, ev.stream_id)
+                if isinstance(ev, h2.events.StreamEnded):
+                    ended.add(ev.stream_id)
+            client_socket.sendall(conn.data_to_send())
+
+        assert statuses == {s1: 200, s2: 200, s3: 200}
+        assert results[s1] == b"A" * (1024 + 512)
+        assert results[s2] == b"B" * (2048 + 256)
+        assert results[s3] == b"C" * 512
+

--- a/tests/test_h2_large_upload.py
+++ b/tests/test_h2_large_upload.py
@@ -1,0 +1,91 @@
+import os
+import socket
+import threading
+import time
+
+import h2.connection
+import h2.events
+
+from zibai.core import serve
+
+
+def sink_app(environ, start_response):
+    # Consume all bytes, then respond with length via header
+    total = 0
+    for chunk in environ["wsgi.input"]:
+        if not chunk:
+            break
+        total += len(chunk)
+    start_response("200 OK", [("X-Total-Length", str(total)), ("Content-Length", "0")])
+    return [b""]
+
+
+def test_h2c_large_upload(socket_and_event):
+    bind_socket, exit_event = socket_and_event
+    bind_socket.listen()
+
+    server_thread = threading.Thread(
+        target=serve,
+        kwargs=dict(
+            app=sink_app,
+            bind_sockets=[bind_socket],
+            max_workers=10,
+            graceful_exit=exit_event,
+        ),
+        daemon=True,
+    )
+    server_thread.start()
+    time.sleep(0.5)
+
+    client_socket = socket.socket(bind_socket.family, bind_socket.type, bind_socket.proto)
+    client_socket.connect(bind_socket.getsockname())
+    with client_socket:
+        conn = h2.connection.H2Connection()
+        conn.initiate_connection()
+        client_socket.sendall(conn.data_to_send())
+
+        stream_id = conn.get_next_available_stream_id()
+        conn.send_headers(stream_id, [(":method", "POST"), (":authority", "x"), (":scheme", "http"), (":path", "/")], end_stream=False)
+        client_socket.sendall(conn.data_to_send())
+
+        size = 16 * 1024 * 1024
+        chunk = os.urandom(64 * 1024)
+        sent = 0
+        while sent < size:
+            window = min(conn.local_flow_control_window(stream_id), conn.max_outbound_frame_size)
+            if window == 0:
+                data = client_socket.recv(65535)
+                assert data
+                events = conn.receive_data(data)
+                client_socket.sendall(conn.data_to_send())
+                continue
+            to_send = chunk[:window]
+            conn.send_data(stream_id, to_send, end_stream=False)
+            client_socket.sendall(conn.data_to_send())
+            sent += len(to_send)
+
+        conn.end_stream(stream_id)
+        client_socket.sendall(conn.data_to_send())
+
+        got_status = None
+        got_total = None
+        while True:
+            data = client_socket.recv(65535)
+            assert data
+            events = conn.receive_data(data)
+            for ev in events:
+                if isinstance(ev, h2.events.ResponseReceived):
+                    for n, v in ev.headers:
+                        if n in (":status", b":status"):
+                            got_status = int(v if isinstance(v, str) else v.decode("ascii"))
+                        if n in ("x-total-length", b"x-total-length"):
+                            got_total = int(v if isinstance(v, str) else v.decode("ascii"))
+                if isinstance(ev, h2.events.StreamEnded):
+                    break
+            client_socket.sendall(conn.data_to_send())
+            if any(isinstance(e, h2.events.StreamEnded) for e in events):
+                break
+
+        assert got_status == 200
+        assert got_total == size
+

--- a/tests/test_h2_large_upload.py
+++ b/tests/test_h2_large_upload.py
@@ -11,11 +11,8 @@ from zibai.core import serve
 
 def sink_app(environ, start_response):
     # Consume all bytes, then respond with length via header
-    total = 0
-    for chunk in environ["wsgi.input"]:
-        if not chunk:
-            break
-        total += len(chunk)
+    body = environ["wsgi.input"].read()
+    total = len(body)
     start_response("200 OK", [("X-Total-Length", str(total)), ("Content-Length", "0")])
     return [b""]
 
@@ -59,7 +56,8 @@ def test_h2c_large_upload(socket_and_event):
                 events = conn.receive_data(data)
                 client_socket.sendall(conn.data_to_send())
                 continue
-            to_send = chunk[:window]
+            remaining = size - sent
+            to_send = chunk[: min(window, remaining)]
             conn.send_data(stream_id, to_send, end_stream=False)
             client_socket.sendall(conn.data_to_send())
             sent += len(to_send)

--- a/tests/test_h2_methods.py
+++ b/tests/test_h2_methods.py
@@ -29,8 +29,7 @@ def method_app(environ, start_response):
         for chunk in environ["wsgi.input"]:
             if chunk:
                 yield chunk
-            else:
-                return
+        return
     start_response("405 Method Not Allowed", [("Content-Length", "0")])
     return [b""]
 

--- a/tests/test_h2_methods.py
+++ b/tests/test_h2_methods.py
@@ -1,0 +1,112 @@
+import socket
+import threading
+import time
+
+import h2.connection
+import h2.events
+import pytest
+
+from zibai.core import serve
+
+
+def method_app(environ, start_response):
+    method = environ["REQUEST_METHOD"].upper()
+    if method == "HEAD":
+        start_response("200 OK", [("Content-Length", "12")])
+        return [b""]
+    if method == "OPTIONS":
+        start_response(
+            "204 No Content",
+            [("Allow", "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"), ("Content-Length", "0")],
+        )
+        return [b""]
+    if method in {"GET", "DELETE"}:
+        start_response("200 OK", [("Content-Length", "0")])
+        return [b""]
+    if method in {"POST", "PUT", "PATCH"}:
+        # echo
+        start_response("200 OK", [])
+        for chunk in environ["wsgi.input"]:
+            if chunk:
+                yield chunk
+            else:
+                return
+    start_response("405 Method Not Allowed", [("Content-Length", "0")])
+    return [b""]
+
+
+@pytest.mark.parametrize("method,has_body,status", [
+    ("GET", False, 200),
+    ("HEAD", False, 200),
+    ("OPTIONS", False, 204),
+    ("DELETE", False, 200),
+    ("POST", True, 200),
+    ("PUT", True, 200),
+    ("PATCH", True, 200),
+])
+def test_h2c_methods(socket_and_event, method, has_body, status):
+    bind_socket, exit_event = socket_and_event
+    bind_socket.listen()
+
+    server_thread = threading.Thread(
+        target=serve,
+        kwargs=dict(
+            app=method_app,
+            bind_sockets=[bind_socket],
+            max_workers=10,
+            graceful_exit=exit_event,
+        ),
+        daemon=True,
+    )
+    server_thread.start()
+    time.sleep(0.5)
+
+    client_socket = socket.socket(bind_socket.family, bind_socket.type, bind_socket.proto)
+    client_socket.connect(bind_socket.getsockname())
+    with client_socket:
+        conn = h2.connection.H2Connection()
+        conn.initiate_connection()
+        client_socket.sendall(conn.data_to_send())
+
+        stream_id = conn.get_next_available_stream_id()
+        headers = [
+            (":method", method),
+            (":authority", "example.com"),
+            (":scheme", "http"),
+            (":path", "/"),
+        ]
+        conn.send_headers(stream_id, headers, end_stream=not has_body)
+        client_socket.sendall(conn.data_to_send())
+
+        if has_body:
+            body = b"abc123"
+            conn.send_data(stream_id, body, end_stream=True)
+            client_socket.sendall(conn.data_to_send())
+
+        received = b""
+        got_status = None
+        while True:
+            data = client_socket.recv(65535)
+            assert data
+            events = conn.receive_data(data)
+            for event in events:
+                if isinstance(event, h2.events.ResponseReceived):
+                    for n, v in event.headers:
+                        if n in (":status", b":status"):
+                            got_status = int(v if isinstance(v, str) else v.decode("ascii"))
+                if isinstance(event, h2.events.DataReceived):
+                    received += event.data
+                    conn.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
+                if isinstance(event, h2.events.StreamEnded):
+                    break
+            client_socket.sendall(conn.data_to_send())
+            if any(isinstance(e, h2.events.StreamEnded) for e in events):
+                break
+
+        assert got_status == status
+        if has_body:
+            assert received == body
+        else:
+            # For HEAD/GET/DELETE/OPTIONS no body expected per app
+            assert received in (b"", b"")
+

--- a/tests/test_http11_keepalive.py
+++ b/tests/test_http11_keepalive.py
@@ -1,0 +1,125 @@
+import socket
+import threading
+import time
+
+import h11
+import pytest
+
+from zibai.core import serve
+
+
+def simple_app(environ, start_response):
+	status = "200 OK"
+	headers = [("Content-Type", "text/plain; charset=utf-8"), ("Content-Length", "2")]
+	start_response(status, headers)
+	return [b"OK"]
+
+
+def expect_app(environ, start_response):
+	# consume body if any
+	_ = environ["wsgi.input"].read()
+	start_response("200 OK", [("Content-Length", "0")])
+	return [b""]
+
+
+@pytest.mark.parametrize("backlog", [10, None])
+@pytest.mark.parametrize("keepalive_timeout", [0.5, 1.0])
+def test_http11_keepalive_timeout(socket_and_event, backlog, keepalive_timeout):
+	bind_socket, exit_event = socket_and_event
+	if backlog is None:
+		bind_socket.listen()
+	else:
+		bind_socket.listen(backlog)
+
+	server_thread = threading.Thread(
+		target=serve,
+		kwargs=dict(
+			app=simple_app,
+			bind_sockets=[bind_socket],
+			max_workers=10,
+			graceful_exit=exit_event,
+			keepalive_timeout=keepalive_timeout,
+		),
+		daemon=True,
+	)
+	server_thread.start()
+
+	time.sleep(0.2)
+
+	client_socket = socket.socket(bind_socket.family, bind_socket.type, bind_socket.proto)
+	client_socket.connect(bind_socket.getsockname())
+	with client_socket:
+		conn = h11.Connection(h11.CLIENT)
+		# First request
+		data = conn.send(h11.Request(method="GET", target="/", headers=[("Host", "example.com")]))
+		client_socket.sendall(data)
+		data = client_socket.recv(4096)
+		conn.receive_data(data)
+		# Read response headers
+		evt = conn.next_event()
+		assert isinstance(evt, h11.Response)
+		# Drain body and EOM so the server enters IDLE keepalive state
+		body_received = False
+		while True:
+			evt = conn.next_event()
+			if evt is h11.NEED_DATA:
+				chunk = client_socket.recv(4096)
+				conn.receive_data(chunk)
+				continue
+			if isinstance(evt, h11.Data):
+				body_received = True
+				continue
+			if isinstance(evt, h11.EndOfMessage):
+				break
+		# Ensure we did receive the body
+		assert body_received
+		# Idle beyond keepalive: expect close
+		time.sleep(keepalive_timeout + 0.3)
+		# The server may have closed; any recv should return b"" or raise
+		try:
+			client_socket.settimeout(0.5)
+			data = client_socket.recv(1)
+			assert data == b""
+		except socket.timeout:
+			pytest.fail("connection not closed after keepalive timeout")
+
+
+@pytest.mark.parametrize("backlog", [10])
+def test_http11_expect_100_continue(socket_and_event, backlog):
+	bind_socket, exit_event = socket_and_event
+	bind_socket.listen(backlog)
+
+	server_thread = threading.Thread(
+		target=serve,
+		kwargs=dict(
+			app=expect_app,
+			bind_sockets=[bind_socket],
+			max_workers=10,
+			graceful_exit=exit_event,
+			keepalive_timeout=1.0,
+		),
+		daemon=True,
+	)
+	server_thread.start()
+
+	time.sleep(0.2)
+
+	client_socket = socket.socket(bind_socket.family, bind_socket.type, bind_socket.proto)
+	client_socket.connect(bind_socket.getsockname())
+	with client_socket:
+		conn = h11.Connection(h11.CLIENT)
+		headers = [("Host", "example.com"), ("Expect", "100-continue"), ("Content-Length", "4")]
+		client_socket.sendall(conn.send(h11.Request(method="POST", target="/", headers=headers)))
+		# We expect informational 100 Continue from server
+		resp = client_socket.recv(4096)
+		conn.receive_data(resp)
+		event = conn.next_event()
+		assert isinstance(event, h11.InformationalResponse) and event.status_code == 100
+		# Now send body
+		client_socket.sendall(conn.send(h11.Data(data=b"TEST")))
+		client_socket.sendall(conn.send(h11.EndOfMessage()))
+		# Read final response
+		resp2 = client_socket.recv(4096)
+		conn.receive_data(resp2)
+		final = conn.next_event()
+		assert isinstance(final, h11.Response) and final.status_code == 200

--- a/tests/test_wsgi_environ.py
+++ b/tests/test_wsgi_environ.py
@@ -1,0 +1,86 @@
+import socket
+import threading
+import time
+
+import h11
+
+from zibai.core import serve
+
+
+def script_app(environ, start_response):
+	status = "200 OK"
+	headers = [("Content-Type", "text/plain; charset=utf-8")]
+	start_response(status, headers)
+	body = f"SCRIPT_NAME={environ['SCRIPT_NAME']},PATH_INFO={environ['PATH_INFO']}".encode()
+	return [body]
+
+
+def _client_request(bind_socket, target):
+	client_socket = socket.socket(bind_socket.family, bind_socket.type, bind_socket.proto)
+	client_socket.connect(bind_socket.getsockname())
+	with client_socket:
+		conn = h11.Connection(h11.CLIENT)
+		client_socket.sendall(conn.send(h11.Request(method="GET", target=target, headers=[("Host", "example.com")])) )
+		data = client_socket.recv(4096)
+		conn.receive_data(data)
+		resp = conn.next_event()
+		assert isinstance(resp, h11.Response) and resp.status_code == 200
+		body = b""
+		while True:
+			evt = conn.next_event()
+			if evt is h11.NEED_DATA:
+				chunk = client_socket.recv(4096)
+				conn.receive_data(chunk)
+				continue
+			if isinstance(evt, h11.Data):
+				body += evt.data
+				continue
+			if isinstance(evt, h11.EndOfMessage):
+				break
+		return body
+
+
+def test_wsgi_script_name_root(socket_and_event):
+	bind_socket, exit_event = socket_and_event
+	bind_socket.listen()
+	server_thread = threading.Thread(
+		target=serve,
+		kwargs=dict(
+			app=script_app,
+			bind_sockets=[bind_socket],
+			max_workers=10,
+			graceful_exit=exit_event,
+			script_name="",
+			keepalive_timeout=1.0,
+		),
+		daemon=True,
+	)
+	server_thread.start()
+	time.sleep(0.2)
+	body = _client_request(bind_socket, "/foo/bar?x=1")
+	assert body == b"SCRIPT_NAME=,PATH_INFO=/foo/bar"
+
+
+def test_wsgi_script_name_prefix(socket_and_event):
+	bind_socket, exit_event = socket_and_event
+	bind_socket.listen()
+	server_thread = threading.Thread(
+		target=serve,
+		kwargs=dict(
+			app=script_app,
+			bind_sockets=[bind_socket],
+			max_workers=10,
+			graceful_exit=exit_event,
+			script_name="/api",
+			keepalive_timeout=1.0,
+		),
+		daemon=True,
+	)
+	server_thread.start()
+	time.sleep(0.2)
+	# exact prefix
+	body = _client_request(bind_socket, "/api")
+	assert body == b"SCRIPT_NAME=/api,PATH_INFO="
+	# nested path
+	body2 = _client_request(bind_socket, "/api/v1/items")
+	assert body2 == b"SCRIPT_NAME=/api,PATH_INFO=/v1/items"


### PR DESCRIPTION
Add HTTP/2 (h2c) protocol support to zibai, enabling direct HTTP/2 connections based on the `h2` library's WSGI example.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ff15b0c-2259-476a-9185-be595616d1aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6ff15b0c-2259-476a-9185-be595616d1aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

